### PR TITLE
update compatibility to telegram-bot-api v5

### DIFF
--- a/telegram.go
+++ b/telegram.go
@@ -48,7 +48,7 @@ func recvWorker(bot *tgbotapi.BotAPI, ctx context.Context) {
 	u := tgbotapi.NewUpdate(0)
 	u.Timeout = 60
 
-	updates, _ := bot.GetUpdatesChan(u)
+	updates := bot.GetUpdatesChan(u)
 
 	for {
 		select {


### PR DESCRIPTION
This project isn't pointing to any specific version of
telegram-bot-api but instead git's HEAD. telegram-bot-api has broken
API backwards compatibility with v5, changing the number of returned
values in GetUpdatesChan.

This change now fixes the GetUpdatesChan call, making midgaard_bot
compatible with telegram-bot-api >= 5.

Closes: #7